### PR TITLE
Don't exit out on network or backend error

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,6 +47,10 @@ trackStream.on('nowPlaying', song => {
   log.info(`Updated song to: ${song.artist["#text"]} - ${song.name}`);
 });
 
+trackStream.on('error', error => {
+    log.error(error)
+})
+
 rpc.on('ready', () => {
   log(`Connected to Discord! (${clientId})`);
   trackStream.start();


### PR DESCRIPTION
Just a simple change because it is ridiculously annoying that it errors out any time anything goes wrong. Still logs the error so if there is an issue you can debug it.